### PR TITLE
test-case for reducing reducible?

### DIFF
--- a/test/error.js
+++ b/test/error.js
@@ -2,6 +2,7 @@
 
 var reduce = require("../reduce")
 var reducible = require("../reducible")
+var isError = require("../is-error")
 var end = require("../end")
 var reduced = require("../reduced")
 
@@ -59,6 +60,10 @@ exports["test thrown errors with reducible"] = function (assert) {
 
   var toArray = function (source, callback) {
     reduce(source, function (value, buffer) {
+      if (isError(value)) {
+        return callback(value)
+      }
+
       called++
       assert.ok(!(value instanceof Error), "value is not an Error")
       if (value === end) {
@@ -80,15 +85,33 @@ exports["test thrown errors with reducible"] = function (assert) {
   assert.equal(called, 4, "toArray is called 4 times")
   assert.equal(callbackCalled, 1, "callback is called once")
 
+  var first = false
+  var second = false
+
   assert.throws(function () {
     toArray(list([1,2,3]), function (err, result) {
+      if (first) {
+        first = false
+        second = true
+
+        assert.equal(err.message, "Some Error", "first error is passed back to me")
+      } else if (second) {
+
+        assert.equal(err.message, "Some Error", "second error is passed back to me")
+        second = "finished"
+      } else {
+        first = true
+      }
+
       callbackCalled++
       throw new Error("Some Error")
     })
-  }, /Some Error/, "Some Error is thrown")
+  }, /Some Error/, "Some Error get's thrown the third time")
 
+  assert.equal(first, false, "first was handled")
+  assert.equal(second, "finished", "second was handled")
   assert.equal(called, 8, "toArray is called 8 times")
-  assert.equal(callbackCalled, 2, "callback is called twice")
+  assert.equal(callbackCalled, 4, "callback is called four times")
 }
 
 if (require.main === module)

--- a/test/error.js
+++ b/test/error.js
@@ -1,0 +1,95 @@
+"use strict";
+
+var reduce = require("../reduce")
+var reducible = require("../reducible")
+var end = require("../end")
+var reduced = require("../reduced")
+
+exports["test thrown errors with arrays"] = function (assert) {
+  var called = 0
+  var callbackCalled = 0
+
+  var toArray = function (source, callback) {
+    reduce(source, function (value, buffer) {
+      called++
+      assert.ok(!(value instanceof Error), "value is not an Error")
+      if (value === end) {
+        callback(null, buffer)
+      } else {
+        buffer.push(value)
+      }
+
+      return buffer
+    }, [])
+  }
+
+  toArray([1,2,3], function (err, result) {
+    callbackCalled++
+    assert.equal(err, null, "err is null")
+    assert.deepEqual(result, [1, 2, 3], "result is array")
+  })
+
+  assert.equal(called, 4, "toArray is called 4 times")
+  assert.equal(callbackCalled, 1, "callback is called once")
+
+  assert.throws(function () {
+    toArray([1,2,3], function (err, result) {
+      callbackCalled++
+      throw new Error("Some Error")
+    })
+  }, /Some Error/, "Some Error is thrown")
+
+  assert.equal(called, 8, "toArray is called 8 times")
+  assert.equal(callbackCalled, 2, "callback is called twice")
+}
+
+exports["test thrown errors with reducible"] = function (assert) {
+  var called = 0
+  var callbackCalled = 0
+
+  var list = function (source) {
+    return reducible(function (next, accumulator) {
+      for (var i = 0; i < source.length; i++) {
+        accumulator = next(source[i], accumulator)
+      }
+
+      next(end, accumulator)
+    })
+  }
+
+  var toArray = function (source, callback) {
+    reduce(source, function (value, buffer) {
+      called++
+      assert.ok(!(value instanceof Error), "value is not an Error")
+      if (value === end) {
+        callback(null, buffer)
+      } else {
+        buffer.push(value)
+      }
+
+      return buffer
+    }, [])
+  }
+
+  toArray(list([1,2,3]), function (err, result) {
+    callbackCalled++
+    assert.equal(err, null, "err is null")
+    assert.deepEqual(result, [1, 2, 3], "result is array")
+  })
+
+  assert.equal(called, 4, "toArray is called 4 times")
+  assert.equal(callbackCalled, 1, "callback is called once")
+
+  assert.throws(function () {
+    toArray(list([1,2,3]), function (err, result) {
+      callbackCalled++
+      throw new Error("Some Error")
+    })
+  }, /Some Error/, "Some Error is thrown")
+
+  assert.equal(called, 8, "toArray is called 8 times")
+  assert.equal(callbackCalled, 2, "callback is called twice")
+}
+
+if (require.main === module)
+  require("test").run(exports)

--- a/test/error.js
+++ b/test/error.js
@@ -12,6 +12,10 @@ exports["test thrown errors with arrays"] = function (assert) {
 
   var toArray = function (source, callback) {
     reduce(source, function (value, buffer) {
+      if (isError(value)) {
+        return callback(value)
+      }
+
       called++
       assert.ok(!(value instanceof Error), "value is not an Error")
       if (value === end) {
@@ -33,15 +37,26 @@ exports["test thrown errors with arrays"] = function (assert) {
   assert.equal(called, 4, "toArray is called 4 times")
   assert.equal(callbackCalled, 1, "callback is called once")
 
+  var first = false
+
   assert.throws(function () {
     toArray([1,2,3], function (err, result) {
       callbackCalled++
+      if (first === false) {
+        first = true
+        assert.equal(err, null)
+        assert.deepEqual(result, [1, 2, 3])
+      } else {
+        assert.equal(err.message, "Some Error")
+      }
+
       throw new Error("Some Error")
     })
   }, /Some Error/, "Some Error is thrown")
 
+  assert.equal(first, true, "toArray callback went through both paths")
   assert.equal(called, 8, "toArray is called 8 times")
-  assert.equal(callbackCalled, 2, "callback is called twice")
+  assert.equal(callbackCalled, 3, "callback is called twice")
 }
 
 exports["test thrown errors with reducible"] = function (assert) {
@@ -86,21 +101,16 @@ exports["test thrown errors with reducible"] = function (assert) {
   assert.equal(callbackCalled, 1, "callback is called once")
 
   var first = false
-  var second = false
 
   assert.throws(function () {
     toArray(list([1,2,3]), function (err, result) {
-      if (first) {
-        first = false
-        second = true
-
-        assert.equal(err.message, "Some Error", "first error is passed back to me")
-      } else if (second) {
-
-        assert.equal(err.message, "Some Error", "second error is passed back to me")
-        second = "finished"
-      } else {
+      if (first === false) {
         first = true
+
+        assert.equal(err, null)
+        assert.deepEqual(result, [1, 2, 3])
+      } else {
+        assert.equal(err.message, "Some Error", "first error is passed back to me")
       }
 
       callbackCalled++
@@ -108,10 +118,9 @@ exports["test thrown errors with reducible"] = function (assert) {
     })
   }, /Some Error/, "Some Error get's thrown the third time")
 
-  assert.equal(first, false, "first was handled")
-  assert.equal(second, "finished", "second was handled")
+  assert.equal(first, true, "first was handled")
   assert.equal(called, 8, "toArray is called 8 times")
-  assert.equal(callbackCalled, 4, "callback is called four times")
+  assert.equal(callbackCalled, 3, "callback is called four times")
 }
 
 if (require.main === module)

--- a/test/index.js
+++ b/test/index.js
@@ -2,5 +2,6 @@
 
 exports["test reduce"] = require("./reduce")
 exports["test reducible"] = require("./reducible")
+exports["test errors"] = require("./error")
 
 require("test").run(exports)

--- a/test/reduce.js
+++ b/test/reduce.js
@@ -112,38 +112,6 @@ exports["test reduce error"] = function(assert) {
   assert.deepEqual(actual, [boom], "error is errored collection")
 }
 
-exports["test thrown errors"] = function (assert) {
-  var called = 0
-
-  var toArray = function (source, callback) {
-    reduce(source, function (value, buffer) {
-      called++
-      assert.ok(!(value instanceof Error), "value is not an Error")
-      if (value === end) {
-        callback(null, buffer)
-      } else {
-        buffer.push(value)
-      }
-
-      return buffer
-    }, [])
-  }
-
-  toArray([1,2,3], function (err, result) {
-    assert.equal(err, null, "err is null")
-    assert.deepEqual(result, [1, 2, 3], "result is array")
-  })
-
-  assert.equal(called, 4)
-
-  assert.throws(function () {
-    toArray([1,2,3], function (err, result) {
-      throw new Error("Some Error")
-    })
-  }, /Some Error/, "Some Error is thrown")
-
-  assert.equal(called, 5)
-}
 
 if (require.main === module)
   require("test").run(exports)

--- a/test/reduce.js
+++ b/test/reduce.js
@@ -112,5 +112,38 @@ exports["test reduce error"] = function(assert) {
   assert.deepEqual(actual, [boom], "error is errored collection")
 }
 
+exports["test thrown errors"] = function (assert) {
+  var called = 0
+
+  var toArray = function (source, callback) {
+    reduce(source, function (value, buffer) {
+      called++
+      assert.ok(!(value instanceof Error), "value is not an Error")
+      if (value === end) {
+        callback(null, buffer)
+      } else {
+        buffer.push(value)
+      }
+
+      return buffer
+    }, [])
+  }
+
+  toArray([1,2,3], function (err, result) {
+    assert.equal(err, null, "err is null")
+    assert.deepEqual(result, [1, 2, 3], "result is array")
+  })
+
+  assert.equal(called, 4)
+
+  assert.throws(function () {
+    toArray([1,2,3], function (err, result) {
+      throw new Error("Some Error")
+    })
+  }, /Some Error/, "Some Error is thrown")
+
+  assert.equal(called, 5)
+}
+
 if (require.main === module)
   require("test").run(exports)


### PR DESCRIPTION
The issue here is that when a function I call (someone else's code) when reducing throws the reduce logic keeps sending me values.

I would expect the exception to get thrown (it does) but also to stop getting values.

Note that the test works fine for arrays but completely fails for a reducible representation of an array.
