### PR TITLE
Remove try catch

### DIFF
--- a/reduce.js
+++ b/reduce.js
@@ -1,16 +1,5 @@
 "use strict";
 
-var globalScope = typeof window !== "undefined" ?
-  window : typeof global !== "undefined" ?
-  global : {}
-
-if (globalScope["__gozala/reducibe__is__defined"]) {
-  console.warn("There are two copies of reducible/reduce. This will most " +
-    "likely cause problems. You should npm dedup")
-} else {
-  globalScope["__gozala/reducibe__is__defined"] = true
-}
-
 var method = require("method")
 
 var isReduced = require("./is-reduced")

--- a/reduce.js
+++ b/reduce.js
@@ -1,5 +1,16 @@
 "use strict";
 
+var globalScope = typeof window !== "undefined" ?
+  window : typeof global !== "undefined" ?
+  global : {}
+
+if (globalScope["__gozala/reducibe__is__defined"]) {
+  console.warn("There are two copies of reducible/reduce. This will most " +
+    "likely cause problems. You should npm dedup")
+} else {
+  globalScope["__gozala/reducibe__is__defined"] = true
+}
+
 var method = require("method")
 
 var isReduced = require("./is-reduced")

--- a/reducible.js
+++ b/reducible.js
@@ -29,54 +29,32 @@ reduce.define(Reducible, function reduceReducible(reducible, next, initial) {
   // matter if consumer is broken and passes in wrong accumulated state back
   // this reducible will still accumulate result as intended.
   var state = initial
-  try {
-    reducible.reduce(function forward(value) {
-      try {
-        // If reduction has already being completed return is set to
-        // an accumulated state boxed via `reduced`. It's set to state
-        // that is return to signal input that reduction is complete.
-        if (result) state = result
-        // if dispatched `value` is is special `end` of input one or an error
-        // just forward to reducer and store last state boxed as `reduced` into
-        // state. Later it will be assigned to result and returned to input
-        // to indicate end of reduction.
-        else if (value === end || isError(value)) {
-          next(value, state)
-          state = reduced(state)
-        }
-        // if non of above just accumulate new state by passing value and
-        // previously accumulate state to reducer.
-        else state = next(value, state)
+  reducible.reduce(function forward(value) {
+    // If reduction has already being completed return is set to
+    // an accumulated state boxed via `reduced`. It's set to state
+    // that is return to signal input that reduction is complete.
+    if (result) state = result
+    // if dispatched `value` is is special `end` of input one or an error
+    // just forward to reducer and store last state boxed as `reduced` into
+    // state. Later it will be assigned to result and returned to input
+    // to indicate end of reduction.
+    else if (value === end || isError(value)) {
+      next(value, state)
+      state = reduced(state)
+    }
+    // if non of above just accumulate new state by passing value and
+    // previously accumulate state to reducer.
+    else state = next(value, state)
 
-        // If state is boxed with `reduced` then accumulation is complete.
-        // Indicated explicitly by a reducer or by end / error of the input.
-        // Either way store it to the result in case broken input attempts to
-        // call forward again.
-        if (isReduced(state)) result = state
+    // If state is boxed with `reduced` then accumulation is complete.
+    // Indicated explicitly by a reducer or by end / error of the input.
+    // Either way store it to the result in case broken input attempts to
+    // call forward again.
+    if (isReduced(state)) result = state
 
-        // return accumulated state back either way.
-        return state
-      }
-      // If error is thrown then forward it to the reducer such that consumer
-      // can apply recovery logic. Also store current `state` boxed with
-      // `reduced` to signal input that reduction is complete.
-      catch (error) {
-        next(error, state)
-        result = reduced(state)
-        return result
-      }
-    })
-  }
-  // It could be that attempt to reduce underlaying reducible throws, if that
-  // is the case still forward an `error` to a reducer and store reduced state
-  // into result, in case process of reduction started before exception and
-  // forward will still be called. Return result either way to signal
-  // completion.
-  catch(error) {
-    next(error, state)
-    result = reduced(state)
-    return result
-  }
+    // return accumulated state back either way.
+    return state
+  })
 })
 
 function reducible(reduce) {


### PR DESCRIPTION
try catch is more trouble then it's worth.

One of the issues I've run into is that when one of your higher order reducible functions doesn't propagate errors in all cases correctly then you get boxed errors and a production debugging nightmare. 

I think something somewhere in reducers doesn't forward errors correctly but that's a separate bug.
